### PR TITLE
Corrected X509Store StoreName mapping for "CertificateAuthority"

### DIFF
--- a/OpenNETCF/OpenNETCF/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/OpenNETCF/OpenNETCF/Security/Cryptography/X509Certificates/X509Store.cs
@@ -23,7 +23,7 @@ namespace OpenNETCF.Security.Cryptography.X509Certificates
                     nameString = "My";
                     break;
                 case StoreName.CertificateAuthority:
-                    nameString = "CertificateAuthority";
+                    nameString = "CA";
                     break;
                 case StoreName.Root:
                     nameString = "Root";


### PR DESCRIPTION
Corrected X509Store StoreName mapping string for StoreName.CertificateAuthority to map to "CA" (instead of "CertificateAuthority") as required by native method CertOpenStore.

Valid values are "My", "Root", "CA". (As can be seen in certcpl.cpp).