### PR TITLE
fix(ServiceCollection): don't crash if "Index" registry value is missing

### DIFF
--- a/OpenNETCF.WindowsCE.Services/OpenNETCF.WindowsCE.Services/ServiceCollection.cs
+++ b/OpenNETCF.WindowsCE.Services/OpenNETCF.WindowsCE.Services/ServiceCollection.cs
@@ -95,12 +95,13 @@ namespace OpenNETCF.WindowsCE.Services
                         using (RegistryKey svcKey = root.OpenSubKey(name, true))
                         {
                             string prefixVal = (string)svcKey.GetValue("Prefix");
-                            int svcIndex = (int)svcKey.GetValue("Index");
+                            int? svcIndex = (int?)svcKey.GetValue("Index");
                             DLLName = (string)svcKey.GetValue("Dll");
 
                             if (!String.IsNullOrEmpty(prefixVal))
                             {
-                                string prefixFull = String.Format("{0}:", prefixVal.ToUpper().Substring(0, 3) + svcIndex.ToString());
+                                string strIndex = (svcIndex == null) ? "" : svcIndex.ToString();
+                                string prefixFull = String.Format("{0}:", prefixVal.ToUpper().Substring(0, 3) + strIndex);
 
                                 // 2. Get handles by way of CreateFile
                                 IntPtr svcHandle = CreateFile(prefixFull, 0, 0, 0, OPEN_EXISTING, 0, 0);


### PR DESCRIPTION
On a device I was working with, one service was missing the "Index" value.

As a result, the current code tried to cast a null to an int and crashed.